### PR TITLE
Drop lifecycle.ignore_changes from ec2 instance

### DIFF
--- a/terraform/pipelet.tf
+++ b/terraform/pipelet.tf
@@ -181,9 +181,6 @@ resource "aws_instance" "jenkins_ec2" {
   tags {
     Name = "${var.ci_hostname}"
   }
-  lifecycle {
-    ignore_changes = ["user_data"]
-  }
 }
 
 resource "aws_route53_record" "pipelet_route" {


### PR DESCRIPTION
This is causing strange diff behavior.  Let's just accept that changes to user data mean the instance is going to get nuked and recreated.