### PR TITLE
Don't render kraken-ci jjb project

### DIFF
--- a/ansible/roles/kraken-ci/tasks/data-volume-common.yaml
+++ b/ansible/roles/kraken-ci/tasks/data-volume-common.yaml
@@ -37,7 +37,7 @@
   template: src=data_volume/job-builder/{{ item }}.jinja2 dest={{ data_container_path }}/job-builder/{{ item }}
   with_items:
     - jenkins_jobs.ini
-    - kraken-ci.yaml
+    - slack-publisher.yaml
 
 - name: Clone jenkins-jobs-builder jobs repo 
   git: >

--- a/ansible/roles/kraken-ci/tasks/jenkins.yaml
+++ b/ansible/roles/kraken-ci/tasks/jenkins.yaml
@@ -64,7 +64,7 @@
       - "{{ secrets_dir }}/docker/config.json:/root/.docker/config.json:ro"
 
 - name: Try updating jenkins jobs in jenkins container
-  shell: docker exec {{ ci_container_name }} jenkins-jobs update -r /etc/jenkins_jobs
+  shell: docker exec {{ ci_container_name }} jenkins-jobs update --recursive --exclude /etc/jenkins_jobs/jobs/excluded-on-jenkins /etc/jenkins_jobs
   register: result
   until: result.rc == 0
   retries: 5

--- a/ansible/roles/kraken-ci/templates/data_volume/job-builder/slack-publisher.yaml.jinja2
+++ b/ansible/roles/kraken-ci/templates/data_volume/job-builder/slack-publisher.yaml.jinja2
@@ -1,0 +1,8 @@
+- publisher:
+    name: slack-publisher
+    publishers:
+      - raw-xml-slack-publisher:
+          slack_api_token: "{{ job_builder.slack_api_token }}"
+          slack_room: "{{ job_builder.slack_room }}"
+          slack_domain: "{{ job_builder.slack_domain }}"
+          ci_hostname: "{{ job_builder.ci_hostname }}"


### PR DESCRIPTION
Instead render copies of kraken-ci-jobs/excluded-on-jenkins/* which is
just the slack-publisher for now