### PR TITLE
Change cloud-config to configure etcd drop-in to not us public

### DIFF
--- a/terraform/templates/cloud-config.tpl
+++ b/terraform/templates/cloud-config.tpl
@@ -5,13 +5,14 @@ coreos:
   hostname: ${hostname}
   ssh_authorized_keys:
     - ${jenkins_ssh_key}
-  etcd:
-    # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
-    # specify the initial size of your cluster with ?size=X
-    discovery: https://discovery.etcd.io/40c9c1017e889f34c5e70fd4812d0311
-    # multi-region and multi-cloud deployments need to use $public_ipv4
-    addr: $private_ipv4:4001
-    peer-addr: $private_ipv4:7001
+  etcd2:
+    name: etcd
+    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
+    initial-cluster: etcd=http://$private_ipv4:2380
+    initial-advertise-peer-urls: http://$private_ipv4:2380
+    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
+    initial-cluster-state: new
   units:
     - name: format-ebs.service
       command: start


### PR DESCRIPTION
discovery. Instead set the cluster state to new so that each time etcd
starts it assumes it is a new cluster. Since jenkins is a cluster of
one, this is sufficent to fix PIP-65.