### PR TITLE
bump executors up to 8

### DIFF
--- a/ansible/roles/kraken-ci/templates/data_volume/config/config.xml.jinja2
+++ b/ansible/roles/kraken-ci/templates/data_volume/config/config.xml.jinja2
@@ -2,7 +2,7 @@
 <hudson>
   <disabledAdministrativeMonitors/>
   <version>1.625.3</version>
-  <numExecutors>5</numExecutors>
+  <numExecutors>8</numExecutors>
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>
   <authorizationStrategy class="org.jenkinsci.plugins.GithubAuthorizationStrategy" plugin="github-oauth@0.22.2">


### PR DESCRIPTION
now that we default to m4.2xlarge's, we've got 8 cores to play with