### PR TITLE
add .idea to the .gitignore file, for JetBrains software settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ ansible/keys
 
 # osx artifacts
 .DS_Store
+.idea


### PR DESCRIPTION
Just a quick addition to the .gitignore for JetBrains based software settings.  InteliJ, Pycharms, Webstorm...etc, etc.