### PR TITLE
mount aws credentials in jenkins

### DIFF
--- a/ansible/roles/kraken-ci/tasks/run-jenkins-container.yaml
+++ b/ansible/roles/kraken-ci/tasks/run-jenkins-container.yaml
@@ -45,3 +45,4 @@
       - /var/run:/ansible
       - /var/lib/docker/gobuild:/var/lib/docker/gobuild
       - "{{ secrets_dir }}/docker/config.json:/root/.docker/config.json:ro"
+      - /root/.aws/credentials:/root/.aws/credentials:ro


### PR DESCRIPTION
intended to set the stage for kraken-ci-jobs to start using this instead of AWS_ env vars