### PR TITLE
Always set ansible_python_interpeter

### DIFF
--- a/ansible/inventory.local
+++ b/ansible/inventory.local
@@ -1,2 +1,2 @@
 [local]
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter="$(which python)"


### PR DESCRIPTION
This prevents needing to specify a specific python interpreter when
running in a virtualenv or any python that's not `/usr/bin/python`
specifically.

Fixes #123